### PR TITLE
Fix missing last material when loading from .mtl (test case provided)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OBJ and MTL loader for WebGL",
   "main": "src/objLoader.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha --reporter spec test/",
     "start": "node ./example/app.js",
     "dev": "webpack-dev-server --devtool eval --progress --colors --content-base build"
   },
@@ -31,6 +31,9 @@
     "node-libs-browser": "^0.5.2",
     "three": "^0.71.0",
     "three-orbit-controls": "^69.0.5",
-    "webpack": "^1.10.1"
+    "webpack": "^1.10.1",
+    "mocha": "^2.3.4",
+	"chai": "^3.4.1",
+	"sinon": "^1.17.2"
   }
 }

--- a/src/objLoader.js
+++ b/src/objLoader.js
@@ -55,6 +55,9 @@ ObjLoader.prototype.load = function(objFilePath, mtlFilePath, callback) {
                 currentMat = self.parseMtl(line, currentMat);
               })
               .on('end', function() {
+                if(currentMat.name) {
+                  self.materials.push(currentMat);
+                }
                 /*Geometry and Materials*/
                 callback(
                   null,

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,63 @@
+var assert = require('chai').assert;
+var fs = require('fs');
+var util = require('util');
+var sinon = require('sinon');
+
+// Mock XHR; must be done before requiring objLoader
+var server = sinon.fakeServer.create();
+require("global/window").XMLHttpRequest = server.xhr;
+
+var ObjLoader = require('../src/objLoader');
+
+describe('Definition', function() {
+  it('should be properly defined', function() {
+    var objloader = new ObjLoader();
+    assert(util.isObject(objloader));
+  });
+});
+
+describe('Parsing', function() {
+  var path = __dirname + '/../example/public/test/objfiles/sponza';
+  var objFilePath = path + '/sponza.obj';
+  var mtlFilePath = path + '/sponza.mtl';
+  var objFileURL = "file://" + objFilePath;
+  var mtlFileURL = "file://" + mtlFilePath;
+
+  function okResponseFor(filePath) {
+    return [ 200, {
+      'Content-Type' : 'text/plain;charset=utf-8'
+    }, fs.readFileSync(filePath, 'utf8') ];
+  }
+
+  beforeEach(function() {
+    server.respondWith('GET', objFileURL, okResponseFor(objFilePath));
+    server.respondWith('GET', mtlFileURL, okResponseFor(mtlFilePath));
+  });
+
+  it('should parse without error and return a meaningful object', function(done) {
+    new ObjLoader().load(objFileURL, mtlFileURL, function(err, result) {
+
+      // Basic sanity checks
+      assert.isNull(err);
+      assert.isDefined(result);
+      assert(util.isObject(result));
+
+      // Expected value is from Blender stats
+      assert.equal(result.vertices.length, 60848);
+
+      // Blender says 40209. Close enough I guess?
+      assert.equal(result.faces.length, 40211);
+
+      // Expected value: "newmtl" count in mtl
+      assert.equal(result.materials.length, 20);
+      
+      // Ensure last material was properly loaded
+      assert.equal(result.materials[19].name, 'sp_00_vrata_kock');
+      assert.equal(result.materials[19].bumpMap, 'VRATA_KO.JPG');
+
+      done();
+    });
+
+    server.respond();
+  });
+});


### PR DESCRIPTION
While using `ObjLoader`, I noticed that the last material ("`newmtl`" entry) from a `.mtl` I loaded was not available in the returned `materials` array.

I have been able to reproduce this behavior with the `sponza` sample model.

So this pull request provides:
- A test case demonstrating this issue (please try it using `npm install && npm run test`).
- A fix for this issue.

I followed your coding style for the fix and test code, and believe the provided test case adds value to this module. Anyway please tell me if adjustments are needed to this PR for you to consider merging it.

Regards,
Olivier.
